### PR TITLE
redux && redux-saga && redux-persist && react-toastify

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "dependencies": {
     "@rocketseat/unform": "^1.5.1",
+    "axios": "^0.19.0",
     "date-fns": "^2.0.0-beta.5",
     "dotenv": "^8.1.0",
+    "history": "^4.10.1",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
@@ -16,7 +18,9 @@
     "react-scripts": "3.1.1",
     "react-spinners-kit": "^1.9.0",
     "react-tag-autocomplete": "^5.11.1",
+    "react-toastify": "^5.4.0",
     "redux": "^4.0.4",
+    "redux-saga": "^1.1.1",
     "styled-components": "^4.3.2",
     "yup": "^0.27.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-tag-autocomplete": "^5.11.1",
     "react-toastify": "^5.4.0",
     "redux": "^4.0.4",
+    "redux-persist": "^6.0.0",
     "redux-saga": "^1.1.1",
     "styled-components": "^4.3.2",
     "yup": "^0.27.0"

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "react-dom": "^16.9.0",
     "react-icons": "^3.7.0",
     "react-map-gl": "^5.0.10",
+    "react-redux": "^7.1.1",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1",
     "react-spinners-kit": "^1.9.0",
     "react-tag-autocomplete": "^5.11.1",
+    "redux": "^4.0.4",
     "styled-components": "^4.3.2",
     "yup": "^0.27.0"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -5,16 +5,20 @@
 
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
 
 import GlobalStyle from './styles/global';
 import Routes from './routes';
+import store from './store';
 
 function App() {
   return (
-    <BrowserRouter>
-      <GlobalStyle />
-      <Routes />
-    </BrowserRouter>
+    <Provider store={store}>
+      <BrowserRouter>
+        <GlobalStyle />
+        <Routes />
+      </BrowserRouter>
+    </Provider>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,33 @@
 /**
  * Base da aplicação
- * Composta de rotas e estilização global.
+ * Composta de rotas, estilização global,
+ * notificação global atráves do `react-toastify` e
+ * estado global com o `react-redux`.
  */
 
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
+import { ToastContainer } from 'react-toastify';
 
 import GlobalStyle from './styles/global';
 import Routes from './routes';
-import store from './store';
+
+// react-router-dom ouvirá por mudanças que acontecerem no history
+import history from './services/history';
+import { store, persistor } from './store';
 
 function App() {
   return (
     <Provider store={store}>
-      <BrowserRouter>
-        <GlobalStyle />
-        <Routes />
-      </BrowserRouter>
+      <PersistGate persistor={persistor}>
+        <Router history={history}>
+          <GlobalStyle />
+          <Routes />
+          <ToastContainer autoClose={3000} hideProgressBar={false} />
+        </Router>
+      </PersistGate>
     </Provider>
   );
 }

--- a/src/pages/Map/index.js
+++ b/src/pages/Map/index.js
@@ -11,7 +11,7 @@ export default function Map({ manifestationsState }) {
   useEffect(() => {
     // TODO função para pegar os dados da api
     setManifestations(manifestationsState);
-  }, []);
+  }, [manifestationsState]);
 
   return (
     <Container>

--- a/src/routes/Route.js
+++ b/src/routes/Route.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 import DefaultLayout from '../pages/_layouts/DefaultLayout';
 
@@ -14,24 +15,23 @@ export default function RouteWrapper({
   isPrivate,
   ...rest
 }) {
-  // flag de autenticação
-  // TODO utilizar redux para pegar o dado
-  const logged = true;
+  // ouve o estado de login do admin
+  const signed = useSelector(state => state.auth.signed);
 
   // caso não esteja logado e acesse uma rota privada redireciona para a página de login
-  if (!logged && isPrivate) {
+  if (!signed && isPrivate) {
     return <Redirect to="/" />;
   }
 
   // caso esteja logado e tente acessar uma rota publica redireciona para a rota privada
-  if (logged && !isPrivate) {
+  if (signed && !isPrivate) {
     // TODO criar rota
     return <Redirect to="/map" />;
   }
 
   // caso esteja logado renderiza o componente com um Wrapper
   // esse Wrapper criara o menu
-  if (logged) {
+  if (signed) {
     return (
       <Route
         {...rest}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,12 @@
+/**
+ * Exporta uma instancia do `Axios` configurada com a url base.
+ * O Axios é uma biblioteca para fazer requisições HTTP.
+ */
+
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:3333',
+});
+
+export default api;

--- a/src/services/history.js
+++ b/src/services/history.js
@@ -1,0 +1,8 @@
+/**
+ * A biblioteca `History` serve para controlar a API de histórico do navegador.
+ */
+import { createBrowserHistory } from 'history';
+
+const history = createBrowserHistory();
+
+export default history;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,5 @@
+import { createStore } from 'redux';
+
+const store = createStore();
+
+export default store;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,13 @@
+/**
+ * Cria a Redux Store que guarda a árvore de estado da aplicação.App
+ * A única forma de mudar os dados da Store é chamando o `dispatch()`.
+ * Para específicar diferentes partes da árvore da aplicação criamos diferentes
+ * Reducers e combinamos eles em uma função apenas, utilizando `combineReducers`.
+ */
 import { createStore } from 'redux';
 
-const store = createStore();
+import rootReducer from './modules/rootReducer';
+
+const store = createStore(rootReducer);
 
 export default store;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,13 +1,40 @@
 /**
- * Cria a Redux Store que guarda a árvore de estado da aplicação.App
- * A única forma de mudar os dados da Store é chamando o `dispatch()`.
- * Para específicar diferentes partes da árvore da aplicação criamos diferentes
- * Reducers e combinamos eles em uma função apenas, utilizando `combineReducers`.
+ * Breve explicação do Redux:
+ *
+ * Redux permite a aplicação ter fácil acesso a um estado global. A Redux `Store`.
+ * No React é usado o hook `useSelector` para acessar a `Store` pelo componente
+ * e o hook `useDispatch` para fazer mudanças na `Store`.
+ *
+ * O `useDispatch()` gera uma função que recebe um objeto, `Action`.
+ * Exemplo de `Action`, `{type: '@auth/SIGN_IN_REQUEST', payload: {...} }`
+ *
+ * O `Reducer` ouve por todas as actions e faz as mudanças necessárias na `Store`.
+ *
+ * O middleware `Redux-Saga` intercepta a `Action` e chama a função expecíficada.
  */
-import { createStore } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import { persistStore } from 'redux-persist';
 
+/**
+ * `rootReducer` e `rootSaga` são agregadores de reducers e de sagas, necessário para poder usar mais de um
+ * `persistReducers` é uma função que retorna os reducers configurados para o Redux-persist
+ */
 import rootReducer from './modules/rootReducer';
+import rootSaga from './modules/rootSaga';
+import persistReducers from './persistReducers';
 
-const store = createStore(rootReducer);
+// cria um middleware Redux-Saga
+const sagaMiddleware = createSagaMiddleware();
 
-export default store;
+// cria um enhancer para Redux Store que aplica um middleware para o método dispatch da Redux Store
+const enhancer = applyMiddleware(sagaMiddleware);
+
+// cria a Redux Store com os reducers e enhancer com o Sagas
+const store = createStore(persistReducers(rootReducer), enhancer);
+const persistor = persistStore(store);
+
+sagaMiddleware.run(rootSaga);
+
+// exporta a Redux Store e a persistência da Redux Store
+export { store, persistor };

--- a/src/store/modules/admin/actions.js
+++ b/src/store/modules/admin/actions.js
@@ -1,0 +1,30 @@
+/**
+ * O `Dispatch` do Redux utiliza uma `Action` para identificar a ação a ser tomada e
+ * os dados que seram guardados
+ *
+ * Seguindo o padrão flux na criação das actions:
+ * https://github.com/redux-utilities/flux-standard-action
+ */
+
+// requisição para editar o perfil
+export function updateProfileRequest(data) {
+  return {
+    type: '@admin/UPDATE_PROFILE_REQUEST',
+    payload: { data },
+  };
+}
+
+// perfil editado com sucesso
+export function updateProfileSuccess(profile) {
+  return {
+    type: '@admin/UPDATE_PROFILE_SUCCESS',
+    payload: { profile },
+  };
+}
+
+// falha na edição do perfil
+export function updateProfileFailure() {
+  return {
+    type: '@admin/UPDATE_PROFILE_FAILURE',
+  };
+}

--- a/src/store/modules/admin/reducer.js
+++ b/src/store/modules/admin/reducer.js
@@ -1,0 +1,3 @@
+export default function user() {
+  return [];
+}

--- a/src/store/modules/admin/reducer.js
+++ b/src/store/modules/admin/reducer.js
@@ -1,3 +1,27 @@
-export default function user() {
-  return [];
+/**
+ * Conceitos de um `Reducer`:
+ * O reducer deve ser puro, que significa que não faz chamadas a API, não tem funções não puras,
+ * que não faz mutações no estado atual, apenas cria um novo estado.
+ */
+
+const INTIAL_STATE = {
+  profile: null,
+};
+
+export default function admin(state = INTIAL_STATE, action) {
+  switch (action.type) {
+    case '@admin/UPDATE_PROFILE_SUCCESS':
+      // guarda o perfil editado
+      return { profile: action.payload.profile };
+
+    case '@auth/SIGN_IN_SUCCESS':
+      // guarda o perfil recebido da API
+      return { profile: action.payload.admin };
+
+    case '@auth/SIGN_OUT':
+      return { profile: null };
+
+    default:
+      return state;
+  }
 }

--- a/src/store/modules/admin/sagas.js
+++ b/src/store/modules/admin/sagas.js
@@ -15,13 +15,13 @@ export function* updateProfile({ payload }) {
       email,
       ...(rest.oldPassword ? rest : {}),
     };
-    const response = yield call(api.put, 'users', profile);
+    const response = yield call(api.put, 'admin', profile);
 
-    toast.success('Perfil atualizado com sucesso!');
+    toast.success('Perfil foi atualizado com sucesso!');
 
     yield put(updateProfileSuccess(response.data));
   } catch (err) {
-    toast.error('Ocorreu um erro interno. 😢');
+    toast.error('Não pôde atualizar perfil.');
     yield put(updateProfileFailure());
   }
 }

--- a/src/store/modules/admin/sagas.js
+++ b/src/store/modules/admin/sagas.js
@@ -1,0 +1,31 @@
+/**
+ * Middleware do Redux responsável por fazer as chamadas a API de forma assíncrona.
+ */
+import { all, call, put, takeLatest } from 'redux-saga/effects';
+import { toast } from 'react-toastify';
+
+import api from '../../../services/api';
+import { updateProfileSuccess, updateProfileFailure } from './actions';
+
+export function* updateProfile({ payload }) {
+  try {
+    const { name, email, ...rest } = payload.data;
+    const profile = {
+      name,
+      email,
+      ...(rest.oldPassword ? rest : {}),
+    };
+    const response = yield call(api.put, 'users', profile);
+
+    toast.success('Perfil atualizado com sucesso!');
+
+    yield put(updateProfileSuccess(response.data));
+  } catch (err) {
+    toast.error('Ocorreu um erro interno. 😢');
+    yield put(updateProfileFailure());
+  }
+}
+
+export default all([
+  takeLatest('@admin/UPDATE_PROFILE_REQUEST', updateProfile),
+]);

--- a/src/store/modules/auth/actions.js
+++ b/src/store/modules/auth/actions.js
@@ -1,0 +1,33 @@
+/**
+ * O `Dispatch` do Redux utiliza uma `Action` para identificar a ação a ser tomada e
+ * os dados que seram guardados
+ *
+ * Seguindo o padrão flux na criação das actions:
+ * https://github.com/redux-utilities/flux-standard-action
+ */
+
+// requisição para login
+export function signInRequest(email, password) {
+  return {
+    type: '@auth/SIGN_IN_REQUEST',
+    payload: { email, password },
+  };
+}
+
+// sucesso no login
+export function signInSuccess(token, admin) {
+  return {
+    type: '@auth/SIGN_IN_SUCCESS',
+    payload: { token, admin },
+  };
+}
+
+// falha no login
+export function signFailure() {
+  return { type: '@auth/SIGN_FAILURE' };
+}
+
+// logout
+export function signOut() {
+  return { type: '@auth/SIGN_OUT' };
+}

--- a/src/store/modules/auth/reducer.js
+++ b/src/store/modules/auth/reducer.js
@@ -1,0 +1,3 @@
+export default function auth() {
+  return [];
+}

--- a/src/store/modules/auth/reducer.js
+++ b/src/store/modules/auth/reducer.js
@@ -1,3 +1,32 @@
-export default function auth() {
-  return [];
+/**
+ * Conceitos de um `Reducer`:
+ * O reducer deve ser puro, que significa que não faz chamadas a API, não tem funções não puras,
+ * que não faz mutações no estado atual, apenas cria um novo estado.
+ */
+
+const INITIAL_STATE = {
+  token: null,
+  signed: false,
+  loading: false,
+};
+
+export default function auth(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case '@auth/SIGN_IN_REQUEST':
+      return { ...state, loading: true };
+
+    case '@auth/SIGN_IN_SUCCESS':
+      // aplica o token recebido no login e marca o admin como logado
+      return { token: action.payload.token, signed: true, loading: false };
+
+    case '@auth/SIGN_FAILURE':
+      return { ...state, loading: false };
+
+    case '@auth/SIGN_OUT':
+      // retira o token e marca o admin como deslogado
+      return { token: null, signed: false, loading: false };
+
+    default:
+      return state;
+  }
 }

--- a/src/store/modules/auth/sagas.js
+++ b/src/store/modules/auth/sagas.js
@@ -13,13 +13,16 @@ export function* signIn({ payload }) {
   try {
     const { email, password } = payload;
 
+    // faz a chamada à API no endereço '/sessions' enviando um JSON contendo email e senha
     const response = yield call(api.post, 'sessions', { email, password });
 
-    const { user, token } = response.data;
+    const { admin, token } = response.data;
 
+    // coloca o Token na Header das requisições HTTP
     api.defaults.headers.Authorization = `Bearer ${token}`;
 
-    yield put(signInSuccess(token, user));
+    // diz ao middleware para dar um dispatch nessa action para a store
+    yield put(signInSuccess(token, admin));
 
     // redireciona o admin para essa url
     history.push('/map');
@@ -29,26 +32,15 @@ export function* signIn({ payload }) {
   }
 }
 
-export function* registerAdmin({ payload }) {
-  try {
-    const { name, email, password } = payload;
-    yield call(api.post, 'admin', {
-      name,
-      email,
-      password,
-    });
-  } catch (err) {
-    toast.error('Falha ao cadastrar um admin.');
-  }
-}
-
+// recuperar o token salvo no storage do navegador
 export function setToken({ payload }) {
-  // caso o usuário não tenha nada salvo
+  // caso o admin não tenha nada salvo
   if (!payload) return;
 
   const { token } = payload.auth;
 
   if (token) {
+    // coloca o Token na Header das chamadas HTTP
     api.defaults.headers.Authorization = `Bearer ${token}`;
   }
 }
@@ -62,6 +54,5 @@ export default all([
   // utilizando a action do redux-persist para pegar o token salvo
   takeLatest('persist/REHYDRATE', setToken),
   takeLatest('@auth/SIGN_IN_REQUEST', signIn),
-  takeLatest('@auth/SIGN_UP_REQUEST', registerAdmin),
   takeLatest('@auth/SIGN_OUT', signOut),
 ]);

--- a/src/store/modules/auth/sagas.js
+++ b/src/store/modules/auth/sagas.js
@@ -1,0 +1,67 @@
+/**
+ * Middleware do Redux responsável por fazer as chamadas a API de forma assíncrona.
+ *
+ */
+import { all, call, put, takeLatest } from 'redux-saga/effects';
+import { toast } from 'react-toastify';
+
+import api from '../../../services/api';
+import history from '../../../services/history'; // manipulador de páginas
+import { signInSuccess, signFailure } from './actions';
+
+export function* signIn({ payload }) {
+  try {
+    const { email, password } = payload;
+
+    const response = yield call(api.post, 'sessions', { email, password });
+
+    const { user, token } = response.data;
+
+    api.defaults.headers.Authorization = `Bearer ${token}`;
+
+    yield put(signInSuccess(token, user));
+
+    // redireciona o admin para essa url
+    history.push('/map');
+  } catch (err) {
+    toast.error('Login não pôde ser feito');
+    yield put(signFailure());
+  }
+}
+
+export function* registerAdmin({ payload }) {
+  try {
+    const { name, email, password } = payload;
+    yield call(api.post, 'admin', {
+      name,
+      email,
+      password,
+    });
+  } catch (err) {
+    toast.error('Falha ao cadastrar um admin.');
+  }
+}
+
+export function setToken({ payload }) {
+  // caso o usuário não tenha nada salvo
+  if (!payload) return;
+
+  const { token } = payload.auth;
+
+  if (token) {
+    api.defaults.headers.Authorization = `Bearer ${token}`;
+  }
+}
+
+export function signOut() {
+  history.push('/');
+}
+
+// intercepta todas essas Actions e só executa a ultima vez clicada.
+export default all([
+  // utilizando a action do redux-persist para pegar o token salvo
+  takeLatest('persist/REHYDRATE', setToken),
+  takeLatest('@auth/SIGN_IN_REQUEST', signIn),
+  takeLatest('@auth/SIGN_UP_REQUEST', registerAdmin),
+  takeLatest('@auth/SIGN_OUT', signOut),
+]);

--- a/src/store/modules/rootReducer.js
+++ b/src/store/modules/rootReducer.js
@@ -1,0 +1,15 @@
+/**
+ * Conforme a aplicação cresce é comum ter vários reducers,
+ * para usar eles ao mesmo tempo é usado a função `combineReducers`
+ */
+import { combineReducers } from 'redux';
+
+// reducers
+import auth from './auth/reducer';
+import admin from './admin/reducer';
+
+/**
+ * recebe um `Object` contendo os `Reducers`
+ * retorna uma `Function`que invoca os `Reducers` e cria um `State` com o mesmo formato passado
+ */
+export default combineReducers({ auth, admin });

--- a/src/store/modules/rootSaga.js
+++ b/src/store/modules/rootSaga.js
@@ -1,0 +1,13 @@
+/**
+ * Junta todos os Sagas e permite execução em paralelo
+ */
+import { all } from 'redux-saga/effects';
+
+import auth from './auth/sagas';
+import admin from './admin/sagas';
+
+// generator function
+export default function* rootSaga() {
+  // `all` junta todos os sagas de forma similar ao Promise.all
+  return yield all([auth, admin]);
+}

--- a/src/store/persistReducers.js
+++ b/src/store/persistReducers.js
@@ -1,0 +1,21 @@
+/**
+ * Wrapper para `redux-persist` com a configuração.
+ * Persiste a informações da Store do Redux, ou seja, sempre que recarregar
+ * a página a Store do Redux vai continuar no mesmo estado.
+ *
+ * github do redux-persist
+ * https://github.com/rt2zz/redux-persist
+ */
+import storage from 'redux-persist/lib/storage';
+import { persistReducer } from 'redux-persist';
+
+export default rootReducer => {
+  return persistReducer(
+    {
+      key: 'ouvidor',
+      storage,
+      whitelist: ['auth', 'admin'],
+    },
+    rootReducer
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,6 +1024,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.6.0":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
+  integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -1680,6 +1687,50 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
+
+"@redux-saga/core@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@redux-saga/core/-/core-1.1.1.tgz#72432130630cca08260086ffc564c2aa5488a0a2"
+  integrity sha512-WKXfj2cYkP0eh74dE1ueMjVDoGJIkppXiMFgx0buVRkXENeZmRxIjM4lh9LEWWFqay7I/Qkw7+cMossa7xXoAQ==
+  dependencies:
+    "@babel/runtime" "^7.6.0"
+    "@redux-saga/deferred" "^1.1.0"
+    "@redux-saga/delay-p" "^1.1.0"
+    "@redux-saga/is" "^1.1.0"
+    "@redux-saga/symbols" "^1.1.0"
+    "@redux-saga/types" "^1.1.0"
+    redux "^4.0.4"
+    typescript-tuple "^2.2.1"
+
+"@redux-saga/deferred@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redux-saga/deferred/-/deferred-1.1.0.tgz#aff018f64a936c288c18bd64ddf9ccfa143db6b4"
+  integrity sha512-wOCJCby3hx14bvrEeFLJ1JJTjJdXDJyC+B3JQ6eiqgzNghylbf969lIYmS2Arf2QuALfUtRBNPXBIMDKG9km4g==
+
+"@redux-saga/delay-p@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redux-saga/delay-p/-/delay-p-1.1.0.tgz#4024f979d0f78763d2e90233be8c922781ae4400"
+  integrity sha512-BcRwXs20kKjgiYEwZARkpVoRIe/hHftW3iwPhdeW4/jPyR9gLv/vG8VsJMF5NDEch+/w/mJtdgSubq+wtOS47g==
+  dependencies:
+    "@redux-saga/symbols" "^1.1.0"
+
+"@redux-saga/is@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redux-saga/is/-/is-1.1.0.tgz#d74358364ebde160bf1b8bd94903ff7684b12d41"
+  integrity sha512-0uFXWGSvDCfNBdROHwEVixNhFbI3S+UGBQfcPXQiYL+CjIjyR3DTg2Z+NFH9xzP+H4Oh/yGtTHDhC0GxYp7HQQ==
+  dependencies:
+    "@redux-saga/symbols" "^1.1.0"
+    "@redux-saga/types" "^1.1.0"
+
+"@redux-saga/symbols@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redux-saga/symbols/-/symbols-1.1.0.tgz#676b277cb5deb48ce723b2b394cbae97f82e8319"
+  integrity sha512-Fzw1wV3j4hbac3MYmgNE18Z53URmQZeilTHZLF7Lm4SQ1jG4fcU47v2kElsEbQXUSaFqj+uJqdRzmDGNb6pRwQ==
+
+"@redux-saga/types@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.1.0.tgz#0e81ce56b4883b4b2a3001ebe1ab298b84237204"
+  integrity sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg==
 
 "@rocketseat/unform@^1.5.1":
   version "1.5.1"
@@ -3122,6 +3173,14 @@ axe-core@^3.3.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.2.tgz#7baf3c55a5cf1621534a2c38735f5a1bf2f7e1a8"
   integrity sha512-lRdxsRt7yNhqpcXQk1ao1BL73OZDzmFCWOG0mC4tGR/r14ohH2payjHwCMQjHGbBKm924eDlmG7utAGHiX/A6g==
 
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 axobject-query@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
@@ -4191,7 +4250,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -5044,7 +5103,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0:
+debug@3.1.0, debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -6439,6 +6498,13 @@ focus-lock@^0.6.3:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.5.tgz#f6eb37832a9b1b205406175f5277396a28c0fce1"
   integrity sha512-i/mVBOoa9o+tl+u9owOJUF8k8L85odZNIsctB+JAK2HFT8jckiBwmk+3uydlm6FN8czgnkIwQtBv6yyAbrzXjw==
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
@@ -7099,6 +7165,18 @@ highlight.js@~9.12.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
   integrity sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=
 
+history@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 history@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
@@ -7653,6 +7731,11 @@ is-buffer@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
+
+is-buffer@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.4:
   version "1.1.4"
@@ -12242,7 +12325,17 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-transition-group@^2.2.1:
+react-toastify@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-5.4.0.tgz#29501618d02cc25329c32bfd7cfeed19b532b2ef"
+  integrity sha512-0cdPq1gyxAcYu0KiDPOYp9nNiqIFDWoi7nyoaSw496DElUnNlcjhc7Aduz8CXrGTRugvjuXd3eplUvFaCeQMNA==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+    classnames "^2.2.6"
+    prop-types "^15.7.2"
+    react-transition-group "^2.6.1"
+
+react-transition-group@^2.2.1, react-transition-group@^2.6.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
@@ -12424,6 +12517,13 @@ redeyed@~0.4.0:
   integrity sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=
   dependencies:
     esprima "~1.0.4"
+
+redux-saga@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.1.1.tgz#7e02879beb02c92030b5fbe746fd70e8bda97dfb"
+  integrity sha512-guSnGJ/uEF8yL8Mn4aNa7HxRGCpVUALCkec9iTTD0fOhQqkF6bRQkBLeS+7/cAH3nFnr299bi/DOurTi1apcCA==
+  dependencies:
+    "@redux-saga/core" "^1.1.1"
 
 redux@^4.0.1, redux@^4.0.4:
   version "4.0.4"
@@ -12731,6 +12831,11 @@ resolve-pathname@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
   integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-protobuf-schema@^2.1.0:
   version "2.1.0"
@@ -14286,6 +14391,25 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript-compare@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/typescript-compare/-/typescript-compare-0.0.2.tgz#7ee40a400a406c2ea0a7e551efd3309021d5f425"
+  integrity sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==
+  dependencies:
+    typescript-logic "^0.0.0"
+
+typescript-logic@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-logic/-/typescript-logic-0.0.0.tgz#66ebd82a2548f2b444a43667bec120b496890196"
+  integrity sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q==
+
+typescript-tuple@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/typescript-tuple/-/typescript-tuple-2.2.1.tgz#7d9813fb4b355f69ac55032e0363e8bb0f04dad2"
+  integrity sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==
+  dependencies:
+    typescript-compare "^0.0.2"
+
 ua-parser-js@^0.7.18:
   version "0.7.20"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
@@ -14658,6 +14782,11 @@ value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
   integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12080,7 +12080,7 @@ react-popper@^1.3.3:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-redux@^7.0.2:
+react-redux@^7.0.2, react-redux@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.1.tgz#ce6eee1b734a7a76e0788b3309bf78ff6b34fa0a"
   integrity sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==
@@ -12425,7 +12425,7 @@ redeyed@~0.4.0:
   dependencies:
     esprima "~1.0.4"
 
-redux@^4.0.1:
+redux@^4.0.1, redux@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
   integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12518,6 +12518,11 @@ redeyed@~0.4.0:
   dependencies:
     esprima "~1.0.4"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-saga@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.1.1.tgz#7e02879beb02c92030b5fbe746fd70e8bda97dfb"


### PR DESCRIPTION
Implementado a redux store, os reducers, os sagas e as actions.
Para entender mais sobre o Redux-Saga: https://redux-saga.js.org/
O Sagas basicamente é um middleware para o Redux.

Como tem mais de um reducer eu uso o `combineReducers` para juntar os reducers e usar eles ao mesmo tempo, no arquivo `rootReducer.js`.
![image](https://user-images.githubusercontent.com/18411691/66319040-c963c780-e8f2-11e9-83bd-06a5282cbe73.png)

E como tem mais de uma sagas eu uso o `all` do `redux-saga/effects`.
![image](https://user-images.githubusercontent.com/18411691/66318990-b650f780-e8f2-11e9-9eca-209f663dced5.png)
Sim, essa função tem um asterisco depois dela, isso uma *generator function*.
Se quiser entender o que é essa coisa: https://codeburst.io/understanding-generators-in-es6-javascript-with-examples-6728834016d5

Para persistir o dados no `localStorage` do navegador eu usei a lib `redux-persist`. 
Docs da lib: https://github.com/rt2zz/redux-persist
O `redux-persist` é usado nos arquivos: `src/App.js`, `src/store/index.js` e `src/store/persistReducers.js`.
O Sagas ouve pela action: `persist/REHYDRATE`, lançada pelo `redux-persist`, *provavelmente* é o `PersistGate` dentro do `App.js` que causa esse despache nessa action. 

Estrutura das pastas:
![image](https://user-images.githubusercontent.com/18411691/66318729-3c207300-e8f2-11e9-9f46-19a9a35eeb6e.png)

Você deve estar se perguntando, "por que não usar o localStorage do navegador"? 
Bem, eu testei aqui e se uma mudança acontecer no localStorage o `routes/Route.js` não atualiza automaticamente. Então eu preferi fazer assim.

O que falta no redux agora?
- Conectar a API.
- Adicionar modulos à Redux Store conforme for necessário.

Qualquer dúvida pode perguntar.